### PR TITLE
Add local settings for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,63 @@
+{
+  "emmet.excludeLanguages": [],
+  "emmet.includeLanguages": {
+    "markdown": "html",
+    "javascript": "javascriptreact",
+    "typescript": "typescriptreact"
+  },
+  "emmet.showSuggestionsAsSnippets": true,
+  "emmet.triggerExpansionOnTab": true,
+  "html.autoClosingTags": true,
+  "javascript.autoClosingTags": true,
+  "javascript.suggest.completeFunctionCalls": true,
+  "typescript.suggest.completeFunctionCalls": true,
+  "javascript.suggest.autoImports": true,
+  "search.exclude": {
+    "**/coverage": true
+  },
+  "typescript.autoClosingTags": true,
+  "typescript.suggest.autoImports": true,
+  "editor.formatOnPaste": true,
+  "editor.formatOnSave": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "eslint.validate": ["javascript", "javascriptreact"],
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ],
+  "eslint.alwaysShowStatus": true,
+  "eslint.format.enable": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "**/*.pyc": true,
+    "**/__pycache__": true,
+    "**/*.js.map": {
+      "when": "$(basename)"
+    }
+  },
+  "python.autoComplete.extraPaths": ["./server/"],
+  "python.formatting.provider": "yapf",
+  "python.formatting.yapfArgs": [
+    "--style={based_on_style: facebook, coalesce_brackets: 1, dedent_closing_brackets: 1, indent_width: 4, split_all_top_level_comma_separated_values: 1, split_before_dict_set_generator: 1}"
+  ],
+  "python.linting.enabled": true,
+  "python.linting.lintOnSave": true,
+  "python.linting.pylintEnabled": true,
+  "python.linting.pylintPath": "./server/.venv/bin/pylint",
+  "python.defaultInterpreterPath": "./server/.venv/bin/python",
+  "[python]": {
+    "editor.tabSize": 4
+  },
+  "python.analysis.extraPaths": ["./server/"],
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "TabNine.tabnine-vscode",
     "VisualStudioExptTeam.vscodeintellicode",
     "xabikos.ReactSnippets",
-    "yzhang.markdown-all-in-one"    
+    "yzhang.markdown-all-in-one"
   ],
   "contributes": {
     "snippets": [


### PR DESCRIPTION
Some files had trailing whitespace and poorly indented code. Adding a `.vscode/settings.json` file I've used before fixes this problem when you save, so it shouldn't happen again.

A number of these settings won't apply directly to this repo, it depends how complex it becomes, if we start adding JavaScript/TypeScript files to do stuff, then it will become more applicable, for now, the main bit is save of format and paste